### PR TITLE
Update regex in app.ts based on ChatGPT suggestion

### DIFF
--- a/src/__tests__/fixblurryimages.ts
+++ b/src/__tests__/fixblurryimages.ts
@@ -3,7 +3,7 @@ import { replaceInFile as replace } from 'replace-in-file';
 export async function fixBlurryImages() {
   const options = {
     files: './public/js/app.js',
-    from: /(p\(i,e\);)(let o=await k\(r,e,i\),a=o.toDataURL\("image\/jpeg"\);)/g,
+    from: /(f\(i,e\);)(let a=await k\(i,e,r\),o=a.toDataURL\("image\/jpeg"\);)/g,
     to: `$1(i.height>2880?(e.height=2880,e.width=Math.floor(2880*i.width/i.height),(i.width>3840??(e.height=Math.floor(3840*i.height/i.width),e.width=3840))):(e.width=i.width,e.height=i.height)),document.dispatchEvent(new CustomEvent("ping", { detail: { type: "toast", msg: "higher resolution captured ✅" } }));$2`,
   }
 


### PR DESCRIPTION
This pull request updates the regex in app.ts based on ChatGPT suggestions. 

### Explanation of changes:

The variables in the regex within the 'fix blurry images' function were replaced to match those in the incomplete code block. Specifically, 'p(i,e);' was replaced with 'f(i,e);' and 'let o=await k(r,e,i),' was replaced with 'let a=await k(i,e,r),'. The rest of the code remains the same.