### PR TITLE
Update regex in app.ts based on ChatGPT suggestion

### DIFF
--- a/src/__tests__/fixblurryimages.ts
+++ b/src/__tests__/fixblurryimages.ts
@@ -3,8 +3,8 @@ import { replaceInFile as replace } from 'replace-in-file'
 export async function fixBlurryImages() {
   const options = {
     files: './public/js/app.js',
-    from: /(f\(i,e\);)(let a=\(await k\(i,e,r\)\).toDataURL\("image\/jpeg"\);)/g,
-    to: `$1(i.height>2880?(e.height=2880,e.width=Math.floor(2880*i.width/i.height),(i.width>3840??(e.height=Math.floor(3840*i.height/i.width),e.width=3840))):(e.width=i.width,e.height=i.height)),document.dispatchEvent(new CustomEvent("ping", { detail: { type: "toast", msg: "higher resolution captured ✅" } }));$2`,
+    from: /(l\(n,e\);)(let r=\(await h\(n,e,i\)\).toDataURL\("image\/jpeg"\);)/g,
+    to: `$1(n.height>2880?(e.height=2880,e.width=Math.floor(2880*n.width/n.height),(n.width>3840??(e.height=Math.floor(3840*n.height/n.width),e.width=3840))):(e.width=n.width,e.height=n.height)),document.dispatchEvent(new CustomEvent("ping", { detail: { type: "toast", msg: "higher resolution captured ✅" } }));$2`,
   }
 
   return await replace(options)


### PR DESCRIPTION
This pull request updates the regex in app.ts based on ChatGPT suggestions. 

### Explanation of changes:

The variables and function calls in the regex pattern were updated to match the new code block. The function call 'f(i,e);' was replaced with 'l(n,e);' and 'let a=(await k(i,e,r)).toDataURL("image/jpeg");' was replaced with 'let r=(await h(n,e,i)).toDataURL("image/jpeg");'. The variables 'i' and 'a' were replaced with 'n' and 'r' respectively. The function 'k' was replaced with 'h'. The number of capturing groups remained the same and special characters were accurately escaped as needed.